### PR TITLE
Refactor kv_store: Replace linear scan array with hash table for improved performance

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -17,38 +17,6 @@ Simulate a basic key-value database similar to Redis for educational purposes.
 ## Data Structure
 
 ```mermaid
-static kv_node* hash_table[HASH_TABLE_SIZE];
-
-## data StrictireData Structure
-graph TD
-    A[hash_table[HASH_TABLE_SIZE]] --> B0[Bucket 0]
-    A --> B1[Bucket 1]
-    A --> B2[Bucket 2]
-    A --> B3[Bucket 3]
-    A --> Bn[Bucket N-1]
-
-    subgraph Bucket 0 [Bucket 0 (hash(key) == 0)]
-        B0 --> K0A["kv_node(key='foo', v
-```mermaid
-static kv_node* hash_table[HASH_TABLE_SIZE];alue='bar')"] --> K0B["kv_node(key='baz', value='qux')"] --> Null0[(null)]
-    end
-
-    subgraph Bucket 1 [Bucket 1 (hash(key) == 1)]
-        B1 --> Null1[(null)]
-    end
-
-    subgraph Bucket 2 [Bucket 2 (hash(key) == 2)]
-        B2 --> K2A["kv_node(key='hello', value='world')"] --> Null2[(null)]
-    end
-
-    subgraph Bucket N-1 [Bucket N-1 (hash(key) == N-1)]
-        Bn --> NullN[(null)]
-    end
-
-    style Null0 fill:#f0f0f0,stroke:#bbb
-    style Null1 fill:#f0f0f0,stroke:#bbb
-    style Null2 fill:#f0f0f0,stroke:#bbb
-    style NullN fill:#f0f0f0,stroke:#bbb
 graph TD
     A[hash_table[HASH_TABLE_SIZE]] --> B0[Bucket 0]
     A --> B1[Bucket 1]

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,6 +14,71 @@ Simulate a basic key-value database similar to Redis for educational purposes.
 - `client_utils.c`: Line-by-line `recv()` handling.
 - `tests/`: Automated command tests.
 
+## Data Structure
+
+```mermaid
+static kv_node* hash_table[HASH_TABLE_SIZE];
+
+## data StrictireData Structure
+graph TD
+    A[hash_table[HASH_TABLE_SIZE]] --> B0[Bucket 0]
+    A --> B1[Bucket 1]
+    A --> B2[Bucket 2]
+    A --> B3[Bucket 3]
+    A --> Bn[Bucket N-1]
+
+    subgraph Bucket 0 [Bucket 0 (hash(key) == 0)]
+        B0 --> K0A["kv_node(key='foo', v
+```mermaid
+static kv_node* hash_table[HASH_TABLE_SIZE];alue='bar')"] --> K0B["kv_node(key='baz', value='qux')"] --> Null0[(null)]
+    end
+
+    subgraph Bucket 1 [Bucket 1 (hash(key) == 1)]
+        B1 --> Null1[(null)]
+    end
+
+    subgraph Bucket 2 [Bucket 2 (hash(key) == 2)]
+        B2 --> K2A["kv_node(key='hello', value='world')"] --> Null2[(null)]
+    end
+
+    subgraph Bucket N-1 [Bucket N-1 (hash(key) == N-1)]
+        Bn --> NullN[(null)]
+    end
+
+    style Null0 fill:#f0f0f0,stroke:#bbb
+    style Null1 fill:#f0f0f0,stroke:#bbb
+    style Null2 fill:#f0f0f0,stroke:#bbb
+    style NullN fill:#f0f0f0,stroke:#bbb
+graph TD
+    A[hash_table[HASH_TABLE_SIZE]] --> B0[Bucket 0]
+    A --> B1[Bucket 1]
+    A --> B2[Bucket 2]
+    A --> B3[Bucket 3]
+    A --> Bn[Bucket N-1]
+
+    subgraph Bucket 0 [Bucket 0 (hash(key) == 0)]
+        B0 --> K0A["kv_node(key='foo', value='bar')"] --> K0B["kv_node(key='baz', value='qux')"] --> Null0[(null)]
+    end
+
+    subgraph Bucket 1 [Bucket 1 (hash(key) == 1)]
+        B1 --> Null1[(null)]
+    end
+
+    subgraph Bucket 2 [Bucket 2 (hash(key) == 2)]
+        B2 --> K2A["kv_node(key='hello', value='world')"] --> Null2[(null)]
+    end
+
+    subgraph Bucket N-1 [Bucket N-1 (hash(key) == N-1)]
+        Bn --> NullN[(null)]
+    end
+
+    style Null0 fill:#f0f0f0,stroke:#bbb
+    style Null1 fill:#f0f0f0,stroke:#bbb
+    style Null2 fill:#f0f0f0,stroke:#bbb
+    style NullN fill:#f0f0f0,stroke:#bbb
+```
+
+
 ## Client response handling
 
 - `recv()` reads byte by byte with `handle_char()` to support fragmentation.

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,7 +9,7 @@ Simulate a basic key-value database similar to Redis for educational purposes.
 - `server.c`: Main loop, socket and command dispatch.
 - `client.c`: TCP client logic.
 - `commands.c`: Logic for each command.
-- `kv_store.c`: In-memory storage.
+- `kv_store.c`: In-memory storage (hash table with chaining).
 - `protocol.c`: Response helpers.
 - `client_utils.c`: Line-by-line `recv()` handling.
 - `tests/`: Automated command tests.
@@ -18,43 +18,29 @@ Simulate a basic key-value database similar to Redis for educational purposes.
 
 ```mermaid
 graph TD
-    A[hash_table[HASH_TABLE_SIZE]] --> B0[Bucket 0]
-    A --> B1[Bucket 1]
-    A --> B2[Bucket 2]
-    A --> B3[Bucket 3]
-    A --> Bn[Bucket N-1]
+    A["hash_table (HASH_TABLE_SIZE)"] --> B0["Bucket 0"]
+    A --> B1["Bucket 1"]
+    A --> B2["Bucket 2"]
+    A --> B3["Bucket 3"]
+    A --> Bn["Bucket N-1"]
 
-    subgraph Bucket 0 [Bucket 0 (hash(key) == 0)]
-        B0 --> K0A["kv_node(key='foo', value='bar')"] --> K0B["kv_node(key='baz', value='qux')"] --> Null0[(null)]
+    subgraph Bucket0 ["Bucket 0 (hash(key) == 0)"]
+        B0 --> K0A["kv_node(key='foo', value='bar')"] --> K0B["kv_node(key='baz', value='qux')"] --> Null0["null"]
     end
 
-    subgraph Bucket 1 [Bucket 1 (hash(key) == 1)]
-        B1 --> Null1[(null)]
+    subgraph Bucket1 ["Bucket 1 (hash(key) == 1)"]
+        B1 --> Null1["null"]
     end
 
-    subgraph Bucket 2 [Bucket 2 (hash(key) == 2)]
-        B2 --> K2A["kv_node(key='hello', value='world')"] --> Null2[(null)]
+    subgraph Bucket2 ["Bucket 2 (hash(key) == 2)"]
+        B2 --> K2A["kv_node(key='hello', value='world')"] --> Null2["null"]
     end
 
-    subgraph Bucket N-1 [Bucket N-1 (hash(key) == N-1)]
-        Bn --> NullN[(null)]
+    subgraph BucketN ["Bucket N-1 (hash(key) == N-1)"]
+        Bn --> NullN["null"]
     end
 
     style Null0 fill:#f0f0f0,stroke:#bbb
     style Null1 fill:#f0f0f0,stroke:#bbb
     style Null2 fill:#f0f0f0,stroke:#bbb
     style NullN fill:#f0f0f0,stroke:#bbb
-```
-
-
-## Client response handling
-
-- `recv()` reads byte by byte with `handle_char()` to support fragmentation.
-- Lines are accumulated until `\n`.
-- `END` is detected to stop reading.
-
-## Possible improvements
-
-- Support for key expiration.
-- Support for data types (lists, hashes).
-- Use of epoll or select for better performance.

--- a/docs/design.md
+++ b/docs/design.md
@@ -13,9 +13,9 @@ Simulate a basic key-value database similar to Redis for educational purposes.
 - `protocol.c`: Response helpers.
 - `client_utils.c`: Line-by-line `recv()` handling.
 - `tests/`: Automated command tests.
-
 ## Data Structure
 
+We use the djb2 algorithm (`hash = ((hash << 5) + hash) + c`) to compute `hash(key) % HASH_TABLE_SIZE`, distributing entries into the bucket array shown below.
 ```mermaid
 graph TD
     A["hash_table (HASH_TABLE_SIZE)"] --> B0["Bucket 0"]

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,7 +9,7 @@ Simulate a basic key-value database similar to Redis for educational purposes.
 - `server.c`: Main loop, socket and command dispatch.
 - `client.c`: TCP client logic.
 - `commands.c`: Logic for each command.
-- `kv_store.c`: In-memory storage (hash table with chaining).
+- `kvstore.c`: In-memory storage (hash table with chaining).
 - `protocol.c`: Response helpers.
 - `client_utils.c`: Line-by-line `recv()` handling.
 - `tests/`: Automated command tests.

--- a/docs/design.md
+++ b/docs/design.md
@@ -44,3 +44,16 @@ graph TD
     style Null1 fill:#f0f0f0,stroke:#bbb
     style Null2 fill:#f0f0f0,stroke:#bbb
     style NullN fill:#f0f0f0,stroke:#bbb
+```
+
+## Client response handling
+
+- `recv()` reads byte by byte with `handle_char()` to support fragmentation.
+- Lines are accumulated until `\n`.
+- `END` is detected to stop reading.
+
+## Possible improvements
+
+- Support for key expiration.
+- Support for data types (lists, hashes).
+- Use of epoll or select for better performance.

--- a/src/commands.c
+++ b/src/commands.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 
 #include "commands.h"
-#include "kv_store.h"
+#include "kvstore.h"
 #include "protocol.h"
 #include "errors.h"
 

--- a/src/kv_store.h
+++ b/src/kv_store.h
@@ -1,9 +1,16 @@
 #ifndef KV_STORE_H
 #define KV_STORE_H
 
-#define MAX_KV_PAIRS 100
+#define HASH_TABLE_SIZE 256 
 #define MAX_KEY_LEN 32
+#define MAX_KV_PAIRS 100
 #define MAX_VAL_LEN 128
+
+typedef struct kv_node {
+    char key[MAX_KEY_LEN];
+    char value[MAX_VAL_LEN];
+    struct kv_node* next;
+} kv_node;
 
 typedef struct {
     char key[MAX_KEY_LEN];

--- a/src/kv_store.h
+++ b/src/kv_store.h
@@ -3,7 +3,6 @@
 
 #define HASH_TABLE_SIZE 256 
 #define MAX_KEY_LEN 32
-#define MAX_KV_PAIRS 100
 #define MAX_VAL_LEN 128
 
 typedef struct kv_node {

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "kv_store.h"
+#include "kvstore.h"
 
 static kv_node* hash_table[HASH_TABLE_SIZE];
 

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -9,7 +9,7 @@ static kv_node* hash_table[HASH_TABLE_SIZE];
 static unsigned int hash(const char* key) {
     unsigned int hash = 5381;
     int c;
-    while ((c = *key++)) {
+    while ((c = (unsigned char)*key++)) {
         hash = ((hash << 5) + hash) + c;
     }
     return hash % HASH_TABLE_SIZE;

--- a/src/kvstore.c
+++ b/src/kvstore.c
@@ -1,51 +1,79 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "kv_store.h"
 
-static kv_pair store[MAX_KV_PAIRS];
+static kv_node* hash_table[HASH_TABLE_SIZE];
+
+static unsigned int hash(const char* key) {
+    unsigned int hash = 5381;
+    int c;
+    while ((c = *key++)) {
+        hash = ((hash << 5) + hash) + c;
+    }
+    return hash % HASH_TABLE_SIZE;
+}
 
 void kv_init() {
-    for (int i = 0; i < MAX_KV_PAIRS; i++) {
-        store[i].key[0] = '\0';
+    for (int i = 0; i < HASH_TABLE_SIZE; i++) {
+        hash_table[i] = NULL;
     }
 }
 
-int kv_set(const char *key, const char *value) {
-    for (int i = 0; i < MAX_KV_PAIRS; i++) {
-        if (strcmp(store[i].key, key) == 0 || store[i].key[0] == '\0') {
-            snprintf(store[i].key, MAX_KEY_LEN, "%s", key);
-            snprintf(store[i].value, MAX_VAL_LEN, "%s", value);
+int kv_set(const char* key, const char* value) {
+    unsigned int index = hash(key);
+    kv_node* node = hash_table[index];
+
+    while (node != NULL) {
+        if (strcmp(node->key, key) == 0) {
+            snprintf(node->value, MAX_VAL_LEN, "%s", value);
             return 0;
         }
+        node = node->next;
     }
-    return -1;
+
+    kv_node* new_node = (kv_node*)malloc(sizeof(kv_node));
+    if (!new_node) return -1;
+
+    snprintf(new_node->key, MAX_KEY_LEN, "%s", key);
+    snprintf(new_node->value, MAX_VAL_LEN, "%s", value);
+    new_node->next = hash_table[index];
+    hash_table[index] = new_node;
+
+    return 0;
 }
 
-const char* kv_get(const char *key) {
-    for (int i = 0; i < MAX_KV_PAIRS; i++) {
-        if (strcmp(store[i].key, key) == 0) {
-            return store[i].value;
+const char* kv_get(const char* key) {
+    unsigned int index = hash(key);
+    kv_node* node = hash_table[index];
+
+    while (node != NULL) {
+        if (strcmp(node->key, key) == 0) {
+            return node->value;
         }
+        node = node->next;
     }
     return NULL;
 }
+int kv_delete(const char* key) {
+    unsigned int index = hash(key);
+    kv_node* node = hash_table[index];
+    kv_node* prev = NULL;
 
-/**
- * @brief Removes a key-value pair from the store by key.
- *
- * Searches for the specified key and deletes the entry if found.
- *
- * @param key The key to remove from the store.
- * @return 0 if the key was found and deleted; -1 if the key does not exist.
- */
-int kv_delete(const char *key) {
-    for (int i = 0; i < MAX_KV_PAIRS; i++) {
-        if (strcmp(store[i].key, key) == 0) {
-            store[i].key[0] = '\0';
-            store[i].value[0] = '\0';
+    while (node != NULL) {
+        if (strcmp(node->key, key) == 0) {
+            if (prev) {
+                prev->next = node->next;
+            } else {
+                hash_table[index] = node->next;
+            }
+            free(node);
             return 0;
         }
+        prev = node;
+        node = node->next;
     }
+
     return -1;
 }

--- a/src/kvstore.h
+++ b/src/kvstore.h
@@ -1,5 +1,5 @@
-#ifndef KV_STORE_H
-#define KV_STORE_H
+#ifndef kvstore_H
+#define kvstore_H
 
 #define HASH_TABLE_SIZE 256 
 #define MAX_KEY_LEN 32

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 
 #include "protocol.h"
-#include "kv_store.h"
+#include "kvstore.h"
 #include "errors.h"
 
 /**

--- a/src/server.c
+++ b/src/server.c
@@ -9,7 +9,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include "kv_store.h"
+#include "kvstore.h"
 #include "logs.h"
 #include "server_utils.h"
 

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -48,7 +48,7 @@ output=$($CLIENT_BIN "PING")
 assert_contains "$output" "PONG" "PING did not return PONG"
 
 # Test Very Long Command
-MAX_VAL_LEN=$(grep '^#define MAX_VAL_LEN' src/kv_store.h | awk '{print $3}')
+MAX_VAL_LEN=$(grep '^#define MAX_VAL_LEN' src/kvstore.h | awk '{print $3}')
 LONG_CMD=$(head -c $((MAX_VAL_LEN + 1)) < /dev/zero | tr '\0' 'A')
 output=$($CLIENT_BIN "SET long $LONG_CMD")
 assert_contains "$output" "ERROR value too long" "SET long command did not return ERROR value too long"

--- a/tests/test_commands.c
+++ b/tests/test_commands.c
@@ -5,7 +5,7 @@
 #include <unistd.h>
 
 #include "../src/commands.h"
-#include "../src/kv_store.h"
+#include "../src/kvstore.h"
 #include "../src/protocol.h"
 #include "../src/errors.h"
 

--- a/tests/test_kvstore.c
+++ b/tests/test_kvstore.c
@@ -6,21 +6,51 @@
 
 int main() {
     kv_init();
+
+    // Test basic set/get/delete
     assert(kv_set("key1", "value1") == 0);
     assert(strcmp(kv_get("key1"), "value1") == 0);
     assert(kv_delete("key1") == 0);
     assert(kv_get("key1") == NULL);
     assert(kv_delete("key1") == -1);
-    /// fill to the maximum number of key-value pairs
-    for (int i = 0; i < MAX_KV_PAIRS; i++) {
+
+    // Test inserting multiple keys
+    const int num_keys = 2000; // Large number to test hash collisions + chaining
+    for (int i = 0; i < num_keys; i++) {
         char key[MAX_KEY_LEN], value[MAX_VAL_LEN];
         snprintf(key, sizeof(key), "key%d", i);
         snprintf(value, sizeof(value), "value%d", i);
         assert(kv_set(key, value) == 0);
     }
-    /// this new add should fail
-    assert(kv_set("key_overflow", "value_overflow") == -1);
 
-    printf("✅ Simple kvstore tests passed\n");
+    // Test retrieving the inserted keys
+    for (int i = 0; i < num_keys; i++) {
+        char key[MAX_KEY_LEN], expected_value[MAX_VAL_LEN];
+        snprintf(key, sizeof(key), "key%d", i);
+        snprintf(expected_value, sizeof(expected_value), "value%d", i);
+        const char* actual_value = kv_get(key);
+        assert(actual_value != NULL);
+        assert(strcmp(actual_value, expected_value) == 0);
+    }
+
+    // Test deleting a subset of keys
+    for (int i = 0; i < num_keys; i += 2) { // Delete every second key
+        char key[MAX_KEY_LEN];
+        snprintf(key, sizeof(key), "key%d", i);
+        assert(kv_delete(key) == 0);
+        assert(kv_get(key) == NULL);
+    }
+
+    // Ensure the other half still exists
+    for (int i = 1; i < num_keys; i += 2) {
+        char key[MAX_KEY_LEN], expected_value[MAX_VAL_LEN];
+        snprintf(key, sizeof(key), "key%d", i);
+        snprintf(expected_value, sizeof(expected_value), "value%d", i);
+        const char* actual_value = kv_get(key);
+        assert(actual_value != NULL);
+        assert(strcmp(actual_value, expected_value) == 0);
+    }
+
+    printf("✅ Hash table kvstore tests passed\n");
     return 0;
 }

--- a/tests/test_kvstore.c
+++ b/tests/test_kvstore.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include "../src/kv_store.h"
+#include "../src/kvstore.h"
 
 int main() {
     kv_init();


### PR DESCRIPTION
Description

This PR introduces a major internal refactoring of the kv_store component:

Before:
	•	The kv_store was implemented as a fixed-size array (store[MAX_KV_PAIRS]) with a linear scan for:
	•	kv_set
	•	kv_get
	•	kv_delete
	•	This resulted in O(n) operations — not scalable as the number of keys grew.

Now:

✅ Replaced the internal structure with a hash table with separate chaining (linked lists per bucket):
	•	Constant-time average lookup, insert, and delete (O(1) average, O(n) worst-case).
	•	No practical limit on number of keys, other than system memory.
	•	The kv_store API remains fully compatible:
	•	kv_set()
	•	kv_get()
	•	kv_delete()

Additional changes:
	•	hash_table array and kv_node linked list structures added.
	•	Removed the old store[MAX_KV_PAIRS] array.
	•	New hash() function (simple djb2).
	•	Updated tests/test_kvstore.c:
	•	Removed test for “overflow” (no longer relevant).
	•	Added tests with 2000 keys to validate hash table behavior under load.
	•	Added delete & re-check tests for robustness.

Minor:
	•	Removed obsolete docs/protocol.md and docs/design.md which no longer match the current architecture.
	•	Updated README.md accordingly:
	•	Removed MSET/MGET usage (not yet fully standardized in protocol).

⸻

Rationale

The old O(n) kv_store implementation was acceptable for learning purposes, but is a major limitation:
	•	Slow as more keys are added.
	•	Not suitable as a base for future features (lists, hashes, expiration, etc).
	•	Moving to a hash table unlocks a clear path to future growth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added comprehensive design and protocol documentation outlining the server communication format and project structure.
- **Bug Fixes**
	- Corrected command syntax in the documentation and updated include directives for consistency.
- **Refactor**
	- Improved key-value store performance by switching to a hash table with chaining, enabling efficient handling of large numbers of keys.
- **Tests**
	- Expanded key-value store tests to cover large-scale insertions, retrievals, and deletions.
- **Documentation**
	- Updated README with new commands, usage examples, and integration test instructions. Added detailed design and protocol documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->